### PR TITLE
Fix GitHub Actions artifact deprecation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         run: python3 generate_pages.py
       - name: Build website
         run: ./build.sh
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: dist
 
@@ -34,5 +34,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v2
+      - uses: actions/deploy-pages@v4
         id: deploy


### PR DESCRIPTION
## Summary
- use the latest `upload-pages-artifact` and `deploy-pages` actions

## Testing
- `python3 generate_pages.py`
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6874366131cc83339de938746497bd77